### PR TITLE
Making staging work again

### DIFF
--- a/deployment/helm/pearl-helm/values.schema.json
+++ b/deployment/helm/pearl-helm/values.schema.json
@@ -70,10 +70,48 @@
                     "description": "Postgres URL to access Postgres instance. This would typically be the URL provided by your managed postgres instance. Should include username and password. Example: postgres://user:pass@rds.example.com:5432/lulcdb"
                 },
                 "image": {
-                    "$ref": "file://./schema-util/image.json"
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "You should not need to edit this, will use the image specified by the upstream chart. Change only if you wish to specify a custom image for this container."
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Tag for docker image. Again, this is specified by upstream. Change this only if you wish to use a custom image / tag combination."
+                        }
+                    }
                 },
                 "resources": {
-                    "$ref": "file://./schema-util/resources.json"
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["string", "number"],
+                                    "description": "No of CPUs requested, eg. 4, or 4000m"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "RAM requested - eg. 4Gi"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["string", "number"],
+                                    "description": "No of CPUs limit"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "Memory limit"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -91,11 +129,49 @@
                     "default": 1999
                 },
                 "image": {
-                    "$ref": "file://./schema-util/image.json"
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "You should not need to edit this, will use the image specified by the upstream chart. Change only if you wish to specify a custom image for this container."
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Tag for docker image. Again, this is specified by upstream. Change this only if you wish to use a custom image / tag combination."
+                        }
+                    }
                 },
                 "resources": {
-                    "$ref": "file://./schema-util/resources.json"
-                }
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["number", "string"],
+                                    "description": "No of CPUs requested, eg. 4"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "RAM requested - eg. 4Gi"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["number", "string"],
+                                    "description": "No of CPUs limit"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "Memory limit"
+                                }
+                            }
+                        }
+                    }
+                }                
             }
         },
         "tiles": {
@@ -150,11 +226,49 @@
                             "default": "tiler"
                         },
                         "image": {
-                            "$ref": "file://./schema-util/image.json"
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "You should not need to edit this, will use the image specified by the upstream chart. Change only if you wish to specify a custom image for this container."
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "description": "Tag for docker image. Again, this is specified by upstream. Change this only if you wish to use a custom image / tag combination."
+                                }
+                            }
                         },
                         "resources": {
-                            "$ref": "file://./schema-util/resources.json"
-                        }                      
+                            "type": "object",
+                            "properties": {
+                                "requests": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": ["number", "string"],
+                                            "description": "No of CPUs requested, eg. 4"
+                                        },
+                                        "memory": {
+                                            "type": "string",
+                                            "description": "RAM requested - eg. 4Gi"
+                                        }
+                                    }
+                                },
+                                "limits": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": ["number", "string"],
+                                            "description": "No of CPUs limit"
+                                        },
+                                        "memory": {
+                                            "type": "string",
+                                            "description": "Memory limit"
+                                        }
+                                    }
+                                }
+                            }
+                        }                       
                     }
                 }
             }
@@ -168,7 +282,35 @@
                     "description": "Enable Redis container, used by API to maintain a cache. Is required by the API, so set to false only for debugging purposes."
                 },
                 "resources": {
-                    "$ref": "file://./schema-util/resources.json"
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["number", "string"],
+                                    "description": "No of CPUs requested, eg. 4"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "RAM requested - eg. 4Gi"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["number", "string"],
+                                    "description": "No of CPUs limit"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "Memory limit"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -176,7 +318,17 @@
             "type": "object",
             "properties": {
                 "image": {
-                    "$ref": "file://./schema-util/image.json"
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "You should not need to edit this, will use the image specified by the upstream chart. Change only if you wish to specify a custom image for this container."
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Tag for docker image. Again, this is specified by upstream. Change this only if you wish to use a custom image / tag combination."
+                        }
+                    }
                 }
             }
         },
@@ -209,7 +361,35 @@
                     "description": "Number of GPUs per instance in your cluster. Used to define size of the placeholder container."
                 },
                 "resources": {
-                    "$ref": "file://./schema-util/resources.json"
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["number", "string"],
+                                    "description": "No of CPUs requested, eg. 4"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "RAM requested - eg. 4Gi"
+                                }
+                            }
+                        },
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": ["number", "string"],
+                                    "description": "No of CPUs limit"
+                                },
+                                "memory": {
+                                    "type": "string",
+                                    "description": "Memory limit"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -226,7 +406,17 @@
                     "description": "Frontend domain, to redirect to www. - eg: example.com"
                 },
                 "image": {
-                    "$ref": "file://./schema-util/image.json"
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "You should not need to edit this, will use the image specified by the upstream chart. Change only if you wish to specify a custom image for this container."
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Tag for docker image. Again, this is specified by upstream. Change this only if you wish to use a custom image / tag combination."
+                        }
+                    }
                 }
             }
         },

--- a/deployment/terraform/resources/ip.tf
+++ b/deployment/terraform/resources/ip.tf
@@ -1,4 +1,7 @@
 resource "azurerm_public_ip" "lulc" {
+  lifecycle {
+    ignore_changes = all
+  }
   name                = "${local.prefix}PublicIP"
   resource_group_name = azurerm_resource_group.lulc.name
   location            = azurerm_resource_group.lulc.location


### PR DESCRIPTION
This is all a bit terrible.

So, changes to the `azurerm` version caused some properties to resources to change. Since terraform isn't great with updating Azure resources in place when properties changed, it wanted to re-create both the cluster and the IP address. This was causing cascading failures.

For now, what I've done is add a lifecycle argument to the Cluster and IP address Azure resources to just not do any updates on those resources.

@geohacker - let's discuss, but I think we should keep it that way. Unfortunately, allowing changes to cluster or IP address properties seems like it just results in too many problems. This is not ideal at all, but I don't have a better way.

For now, going to merge this and have staging work again.

Also, using $refs in the values.schema.json didn't quite work on CI, and had to revert that change as well.
