### PR TITLE
lock azurerm version in providers.tf

### DIFF
--- a/deployment/terraform/resources/providers.tf
+++ b/deployment/terraform/resources/providers.tf
@@ -6,6 +6,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
+      version = "=3.4.0"
+    }
+    helm = {
+      source = "hashicorp/helm"
+      version = "=2.5.1"
     }
   }
 }


### PR DESCRIPTION
Specify exact versions of `azurerm` and `helm` providers to use. Refs #12 .

It seems like there are two ways of "locking" versions of providers. One if this, to specify it in the providers.tf. The other would be to create a `.terraform.lock.hcl` file with the locked dependencies.

The problem with that approach is that I needed to create a separate lockfile for `dev`, `staging`, and `production`, and that seemed like a lot of hassle - to remember to update those all locally, keep in sync, etc.

This seemed cleaner, but we can use the other approach if that seems better.

cc @geohacker 