### PR TITLE
ci: pin GitHub Actions to SHA digests (fix zizmor unpinned-uses)

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -16,13 +16,13 @@ jobs:
     env:
       AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.LULCCI_ASCS }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Docker Pull
         run: docker-compose pull
 
       - name: Docker Layer Caching
-        uses: satackey/action-docker-layer-caching@v0.0.11
+        uses: satackey/action-docker-layer-caching@46d2c640b1d8ef50d185452ad6fb324e6bd1d052 # v0.0.11
         continue-on-error: true
 
       - name: Docker Build

--- a/.github/workflows/chartpress.yml
+++ b/.github/workflows/chartpress.yml
@@ -25,15 +25,15 @@ jobs:
       servicePrincipalKey: ${{ secrets.TERRAFORM_SERVICE_PRINCIPAL_KEY }}
       storageAccessKey: ${{ secrets.TERRAFORM_STORAGE_KEY }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Login to Azure Container Registry
-      uses: azure/docker-login@v1
+      uses: azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1
       with:
         login-server: ${{ env.STAGING_REGISTRY_NAME }}.azurecr.io
         username: ${{ secrets.TERRAFORM_REGISTRY_USERNAME }}
         password: ${{ secrets.TERRAFORM_REGISTRY_PASSWORD }}
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: '3.11'
     - name: Setup git

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.draft == false
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Docker Pull
         run: docker-compose pull

--- a/.github/workflows/socket_test.yml
+++ b/.github/workflows/socket_test.yml
@@ -14,13 +14,13 @@ jobs:
     if: github.event.pull_request.draft == false
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Docker Pull
         run: docker-compose pull
 
       - name: Docker Layer Caching
-        uses: satackey/action-docker-layer-caching@v0.0.11
+        uses: satackey/action-docker-layer-caching@46d2c640b1d8ef50d185452ad6fb324e6bd1d052 # v0.0.11
         continue-on-error: true
 
       - name: Docker Socket Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
     env:
       AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.LULCDATA_ASCS }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Docker Pull
         run: docker-compose pull
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
          node-version: 18
 


### PR DESCRIPTION
Pins all GitHub Actions workflow steps to full SHA digests, eliminating the `unpinned-uses` supply-chain risk identified by zizmor (10 findings fixed).

Closes #91

### Recommended next steps

1. Enable Dependabot for `github-actions` to keep pinned SHAs up-to-date automatically (a companion PR may be opened for this repo).
2. Add [zizmor-action](https://github.com/zizmorcore/zizmor-action?tab=readme-ov-file#usage-with-github-advanced-security-recommended) for continuous workflow security scanning in CI.

---
_Generated by [ds-security-scanning](https://github.com/developmentseed/ds-security-scanning) zizmor-cli-unpinned-uses_